### PR TITLE
Add composite observers to minimize configuration complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Version 5.0.0
+
+## Bugfixes
+
+* None
+
+## Features
+
+* Add composite observers to minimize configuration complexity
+* Switch to latest techdivision/import 7.0.* version as dependency
+* Make Actions and ActionInterfaces deprecated, replace DI configuration with GenericAction + GenericIdentifierAction
+
 # Version 4.0.0
 
 ## Bugfixes

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "OSL-3.0",
     "require": {
         "php": ">=5.6.0",
-        "techdivision/import-customer": "4.0.*"
+        "techdivision/import-customer": "5.0.*"
     },
     "require-dev": {
         "doctrine/dbal": "2.5.*",

--- a/etc/techdivision-import.json
+++ b/etc/techdivision-import.json
@@ -97,16 +97,7 @@
               "observers": [
                 {
                   "import": [
-                    "import_customer_address.observer.clear.customer.address",
-                    "import_customer_address.observer.customer.address",
-                    "import_customer_address.observer.customer.address.attribute",
-                    "import_customer_address.observer.default.billing.address",
-                    "import_customer_address.observer.default.shipping.address"
-                  ]
-                },
-                {
-                  "post-import": [
-                    "import_customer_address.observer.clean.up"
+                    "import_customer_address.observer.composite.replace"
                   ]
                 }
               ]
@@ -147,15 +138,7 @@
               "observers": [
                 {
                   "import": [
-                    "import_customer_address.observer.customer.address",
-                    "import_customer_address.observer.customer.address.attribute.update",
-                    "import_customer_address.observer.default.billing.address",
-                    "import_customer_address.observer.default.shipping.address"
-                  ]
-                },
-                {
-                  "post-import": [
-                    "import_customer_address.observer.clean.up"
+                    "import_customer_address.observer.composite.add_update"
                   ]
                 }
               ]

--- a/src/Actions/CustomerAddressAction.php
+++ b/src/Actions/CustomerAddressAction.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer-address
  * @link      http://www.techdivision.com
@@ -26,11 +26,12 @@ use TechDivision\Import\Actions\AbstractAction;
 /**
  * An action implementation that provides CRUD functionality for customer address.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer-address
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer-address
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0 use \TechDivision\Import\Actions\GenericIdentifierAction instead
  */
 class CustomerAddressAction extends AbstractAction implements CustomerAddressActionInterface
 {

--- a/src/Actions/CustomerAddressActionInterface.php
+++ b/src/Actions/CustomerAddressActionInterface.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer-address
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\ActionInterface;
 /**
  * Interface for action implementations that provides CRUD functionality for customer address.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer-address
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer-address
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0
  */
 interface CustomerAddressActionInterface extends ActionInterface
 {

--- a/src/Actions/CustomerAddressDatetimeAction.php
+++ b/src/Actions/CustomerAddressDatetimeAction.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer-address
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\AbstractAction;
 /**
  * An action implementation that provides CRUD functionality for customer address datetime attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer-address
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer-address
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0 use \TechDivision\Import\Actions\GenericAction instead
  */
 class CustomerAddressDatetimeAction extends AbstractAction implements CustomerAddressDatetimeActionInterface
 {

--- a/src/Actions/CustomerAddressDatetimeActionInterface.php
+++ b/src/Actions/CustomerAddressDatetimeActionInterface.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer-address
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\ActionInterface;
 /**
  * Interface for customer datetime action implementations that provides CRUD functionality for customer address datetime attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer-address
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer-address
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0
  */
 interface CustomerAddressDatetimeActionInterface extends ActionInterface
 {

--- a/src/Actions/CustomerAddressDecimalAction.php
+++ b/src/Actions/CustomerAddressDecimalAction.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer-address
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\AbstractAction;
 /**
  * An action implementation that provides CRUD functionality for customer address decimal attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer-address
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer-address
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0 use \TechDivision\Import\Actions\GenericAction instead
  */
 class CustomerAddressDecimalAction extends AbstractAction implements CustomerAddressDecimalActionInterface
 {

--- a/src/Actions/CustomerAddressDecimalActionInterface.php
+++ b/src/Actions/CustomerAddressDecimalActionInterface.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer-address
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\ActionInterface;
 /**
  * Interface for customer datetime action implementations that provides CRUD functionality for customer address decimal attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer-address
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer-address
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0
  */
 interface CustomerAddressDecimalActionInterface extends ActionInterface
 {

--- a/src/Actions/CustomerAddressIntAction.php
+++ b/src/Actions/CustomerAddressIntAction.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer-address
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\AbstractAction;
 /**
  * An action implementation that provides CRUD functionality for customer address integer attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer-address
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer-address
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0 use \TechDivision\Import\Actions\GenericAction instead
  */
 class CustomerAddressIntAction extends AbstractAction implements CustomerAddressIntActionInterface
 {

--- a/src/Actions/CustomerAddressIntActionInterface.php
+++ b/src/Actions/CustomerAddressIntActionInterface.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer-address
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\ActionInterface;
 /**
  * Interface for customer datetime action implementations that provides CRUD functionality for customer address integer attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer-address
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer-address
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0
  */
 interface CustomerAddressIntActionInterface extends ActionInterface
 {

--- a/src/Actions/CustomerAddressTextAction.php
+++ b/src/Actions/CustomerAddressTextAction.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer-address
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\AbstractAction;
 /**
  * An action implementation that provides CRUD functionality for customer address text attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer-address
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer-address
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0 use \TechDivision\Import\Actions\GenericAction instead
  */
 class CustomerAddressTextAction extends AbstractAction implements CustomerAddressTextActionInterface
 {

--- a/src/Actions/CustomerAddressTextActionInterface.php
+++ b/src/Actions/CustomerAddressTextActionInterface.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer-address
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\ActionInterface;
 /**
  * Interface for customer datetime action implementations that provides CRUD functionality for customer address text attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer-address
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer-address
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0
  */
 interface CustomerAddressTextActionInterface extends ActionInterface
 {

--- a/src/Actions/CustomerAddressVarcharAction.php
+++ b/src/Actions/CustomerAddressVarcharAction.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer-address
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\AbstractAction;
 /**
  * An action implementation that provides CRUD functionality for customer address varchar attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer-address
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer-address
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0 use \TechDivision\Import\Actions\GenericAction instead
  */
 class CustomerAddressVarcharAction extends AbstractAction implements CustomerAddressVarcharActionInterface
 {

--- a/src/Actions/CustomerAddressVarcharActionInterface.php
+++ b/src/Actions/CustomerAddressVarcharActionInterface.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer-address
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\ActionInterface;
 /**
  * Interface for customer datetime action implementations that provides CRUD functionality for customer address varchar attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer-address
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer-address
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0
  */
 interface CustomerAddressVarcharActionInterface extends ActionInterface
 {

--- a/src/Services/CustomerAddressBunchProcessor.php
+++ b/src/Services/CustomerAddressBunchProcessor.php
@@ -20,19 +20,14 @@
 
 namespace TechDivision\Import\Customer\Address\Services;
 
+use TechDivision\Import\Actions\ActionInterface;
 use TechDivision\Import\Connection\ConnectionInterface;
 use TechDivision\Import\Repositories\EavAttributeRepositoryInterface;
+use TechDivision\Import\Repositories\EavEntityTypeRepositoryInterface;
 use TechDivision\Import\Repositories\EavAttributeOptionValueRepositoryInterface;
 use TechDivision\Import\Customer\Repositories\CustomerRepositoryInterface;
 use TechDivision\Import\Customer\Address\Assemblers\CustomerAddressAttributeAssemblerInterface;
-use TechDivision\Import\Customer\Address\Actions\CustomerAddressActionInterface;
-use TechDivision\Import\Customer\Address\Actions\CustomerAddressIntActionInterface;
-use TechDivision\Import\Customer\Address\Actions\CustomerAddressTextActionInterface;
-use TechDivision\Import\Customer\Address\Actions\CustomerAddressVarcharActionInterface;
-use TechDivision\Import\Customer\Address\Actions\CustomerAddressDecimalActionInterface;
-use TechDivision\Import\Customer\Address\Actions\CustomerAddressDatetimeActionInterface;
 use TechDivision\Import\Customer\Address\Repositories\CustomerAddressRepositoryInterface;
-use TechDivision\Import\Repositories\EavEntityTypeRepositoryInterface;
 
 /**
  * The customer address bunch processor implementation.
@@ -91,42 +86,42 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
     /**
      * The action for customer address CRUD methods.
      *
-     * @var \TechDivision\Import\Customer\Address\Actions\CustomerAddressActionInterface
+     * @var \TechDivision\Import\Actions\ActionInterface
      */
     protected $customerAddressAction;
 
     /**
      * The action for customer address varchar attribute CRUD methods.
      *
-     * @var \TechDivision\Import\Customer\Address\Actions\CustomerAddressVarcharActionInterface
+     * @var \TechDivision\Import\Actions\ActionInterface
      */
     protected $customerAddressVarcharAction;
 
     /**
      * The action for customer address text attribute CRUD methods.
      *
-     * @var \TechDivision\Import\Customer\Address\Actions\CustomerAddressTextActionInterface
+     * @var \TechDivision\Import\Actions\ActionInterface
      */
     protected $customerAddressTextAction;
 
     /**
      * The action for customer address int attribute CRUD methods.
      *
-     * @var \TechDivision\Import\Customer\Address\Actions\CustomerAddressIntActionInterface
+     * @var \TechDivision\Import\Actions\ActionInterface
      */
     protected $customerAddressIntAction;
 
     /**
      * The action for customer address decimal attribute CRUD methods.
      *
-     * @var \TechDivision\Import\Customer\Address\Actions\CustomerAddressDecimalActionInterface
+     * @var \\TechDivision\Import\Actions\ActionInterface
      */
     protected $customerAddressDecimalAction;
 
     /**
      * The action for customer address datetime attribute CRUD methods.
      *
-     * @var \TechDivision\Import\Customer\Address\Actions\CustomerAddressDatetimeActionInterface
+     * @var \TechDivision\Import\Actions\ActionInterface
      */
     protected $customerAddressDatetimeAction;
 
@@ -147,12 +142,12 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
      * @param \TechDivision\Import\Customer\Repositories\CustomerRepositoryInterface                      $customerRepository                The customer repository to use
      * @param \TechDivision\Import\Customer\Address\Repositories\CustomerAddressRepositoryInterface       $customerAddressRepository         The customer address repository to use
      * @param \TechDivision\Import\Repositories\EavEntityTypeRepositoryInterface                          $eavEntityTypeRepository           The EAV entity type repository to use
-     * @param \TechDivision\Import\Customer\Address\Actions\CustomerAddressActionInterface                $customerAddressAction             The customer address action to use
-     * @param \TechDivision\Import\Customer\Address\Actions\CustomerAddressDatetimeActionInterface        $customerAddressDatetimeAction     The customer address datetime action to use
-     * @param \TechDivision\Import\Customer\Address\Actions\CustomerAddressDecimalActionInterface         $customerAddressDecimalAction      The customer address decimal action to use
-     * @param \TechDivision\Import\Customer\Address\Actions\CustomerAddressIntActionInterface             $customerAddressIntAction          The customer address integer action to use
-     * @param \TechDivision\Import\Customer\Address\Actions\CustomerAddressTextActionInterface            $customerAddressTextAction         The customer address text action to use
-     * @param \TechDivision\Import\Customer\Address\Actions\CustomerAddressVarcharActionInterface         $customerAddressVarcharAction      The customer address varchar action to use
+     * @param \TechDivision\Import\Actions\ActionInterface                                                $customerAddressAction             The customer address action to use
+     * @param \TechDivision\Import\Actions\ActionInterface                                                $customerAddressDatetimeAction     The customer address datetime action to use
+     * @param \TechDivision\Import\Actions\ActionInterface                                                $customerAddressDecimalAction      The customer address decimal action to use
+     * @param \TechDivision\Import\Actions\ActionInterface                                                $customerAddressIntAction          The customer address integer action to use
+     * @param \TechDivision\Import\Actions\ActionInterface                                                $customerAddressTextAction         The customer address text action to use
+     * @param \TechDivision\Import\Actions\ActionInterface                                                $customerAddressVarcharAction      The customer address varchar action to use
      */
     public function __construct(
         ConnectionInterface $connection,
@@ -162,12 +157,12 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
         CustomerRepositoryInterface $customerRepository,
         CustomerAddressRepositoryInterface $customerAddressRepository,
         EavEntityTypeRepositoryInterface $eavEntityTypeRepository,
-        CustomerAddressActionInterface $customerAddressAction,
-        CustomerAddressDatetimeActionInterface $customerAddressDatetimeAction,
-        CustomerAddressDecimalActionInterface $customerAddressDecimalAction,
-        CustomerAddressIntActionInterface $customerAddressIntAction,
-        CustomerAddressTextActionInterface $customerAddressTextAction,
-        CustomerAddressVarcharActionInterface $customerAddressVarcharAction
+        ActionInterface $customerAddressAction,
+        ActionInterface $customerAddressDatetimeAction,
+        ActionInterface $customerAddressDecimalAction,
+        ActionInterface $customerAddressIntAction,
+        ActionInterface $customerAddressTextAction,
+        ActionInterface $customerAddressVarcharAction
     ) {
         $this->setConnection($connection);
         $this->setCustomerAddressAttributeAssembler($customerAddressAttributeAssembler);
@@ -296,11 +291,11 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
     /**
      * Set's the action with the customer address CRUD methods.
      *
-     * @param \TechDivision\Import\Customer\Address\Actions\CustomerAddressActionInterface $customerAddressAction The action with the customer CRUD methods
+     * @param \TechDivision\Import\Actions\ActionInterface $customerAddressAction The action with the customer CRUD methods
      *
      * @return void
      */
-    public function setCustomerAddressAction(CustomerAddressActionInterface $customerAddressAction)
+    public function setCustomerAddressAction(ActionInterface $customerAddressAction)
     {
         $this->customerAddressAction = $customerAddressAction;
     }
@@ -308,7 +303,7 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
     /**
      * Return's the action with the customer address CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Address\Actions\CustomerAddressActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerAddressAction()
     {
@@ -318,11 +313,11 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
     /**
      * Set's the action with the customer address varchar attribute CRUD methods.
      *
-     * @param \TechDivision\Import\Customer\Address\Actions\CustomerAddressVarcharActionInterface $customerAddressVarcharAction The action with the customer varchar attriute CRUD methods
+     * @param \TechDivision\Import\Actions\ActionInterface $customerAddressVarcharAction The action with the customer varchar attriute CRUD methods
      *
      * @return void
      */
-    public function setCustomerAddressVarcharAction(CustomerAddressVarcharActionInterface $customerAddressVarcharAction)
+    public function setCustomerAddressVarcharAction(ActionInterface $customerAddressVarcharAction)
     {
         $this->customerAddressVarcharAction = $customerAddressVarcharAction;
     }
@@ -330,7 +325,7 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
     /**
      * Return's the action with the customer address varchar attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Address\Actions\CustomerAddressVarcharActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerAddressVarcharAction()
     {
@@ -340,11 +335,11 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
     /**
      * Set's the action with the customer address text attribute CRUD methods.
      *
-     * @param \TechDivision\Import\Customer\Address\Actions\CustomerAddressTextActionInterface $customerAddressTextAction The action with the customer text attriute CRUD methods
+     * @param \TechDivision\Import\Actions\ActionInterface $customerAddressTextAction The action with the customer text attriute CRUD methods
      *
      * @return void
      */
-    public function setCustomerAddressTextAction(CustomerAddressTextActionInterface $customerAddressTextAction)
+    public function setCustomerAddressTextAction(ActionInterface $customerAddressTextAction)
     {
         $this->customerAddressTextAction = $customerAddressTextAction;
     }
@@ -352,7 +347,7 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
     /**
      * Return's the action with the customer address text attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Address\Actions\CustomerAddressTextActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerAddressTextAction()
     {
@@ -362,11 +357,11 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
     /**
      * Set's the action with the customer address int attribute CRUD methods.
      *
-     * @param \TechDivision\Import\Customer\Address\Actions\CustomerAddressIntActionInterface $customerAddressIntAction The action with the customer int attriute CRUD methods
+     * @param \TechDivision\Import\Actions\ActionInterface $customerAddressIntAction The action with the customer int attriute CRUD methods
      *
      * @return void
      */
-    public function setCustomerAddressIntAction(CustomerAddressIntActionInterface $customerAddressIntAction)
+    public function setCustomerAddressIntAction(ActionInterface $customerAddressIntAction)
     {
         $this->customerAddressIntAction = $customerAddressIntAction;
     }
@@ -374,7 +369,7 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
     /**
      * Return's the action with the customer address int attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Address\Actions\CustomerAddressIntActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerAddressIntAction()
     {
@@ -384,11 +379,11 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
     /**
      * Set's the action with the customer address decimal attribute CRUD methods.
      *
-     * @param \TechDivision\Import\Customer\Address\Actions\CustomerAddressDecimalActionInterface $customerAddressDecimalAction The action with the customer decimal attriute CRUD methods
+     * @param \TechDivision\Import\Actions\ActionInterface $customerAddressDecimalAction The action with the customer decimal attriute CRUD methods
      *
      * @return void
      */
-    public function setCustomerAddressDecimalAction(CustomerAddressDecimalActionInterface $customerAddressDecimalAction)
+    public function setCustomerAddressDecimalAction(ActionInterface $customerAddressDecimalAction)
     {
         $this->customerAddressDecimalAction = $customerAddressDecimalAction;
     }
@@ -396,7 +391,7 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
     /**
      * Return's the action with the customer address decimal attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Address\Actions\CustomerAddressDecimalActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerAddressDecimalAction()
     {
@@ -406,11 +401,11 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
     /**
      * Set's the action with the customer address datetime attribute CRUD methods.
      *
-     * @param \TechDivision\Import\Customer\Address\Actions\CustomerAddressDatetimeActionInterface $customerAddressDatetimeAction The action with the customer datetime attriute CRUD methods
+     * @param \TechDivision\Import\Actions\ActionInterface $customerAddressDatetimeAction The action with the customer datetime attriute CRUD methods
      *
      * @return void
      */
-    public function setCustomerAddressDatetimeAction(CustomerAddressDatetimeActionInterface $customerAddressDatetimeAction)
+    public function setCustomerAddressDatetimeAction(ActionInterface $customerAddressDatetimeAction)
     {
         $this->customerAddressDatetimeAction = $customerAddressDatetimeAction;
     }
@@ -418,7 +413,7 @@ class CustomerAddressBunchProcessor implements CustomerAddressBunchProcessorInte
     /**
      * Return's the action with the customer address datetime attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Address\Actions\CustomerAddressDatetimeActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerAddressDatetimeAction()
     {

--- a/src/Services/CustomerAddressBunchProcessorInterface.php
+++ b/src/Services/CustomerAddressBunchProcessorInterface.php
@@ -44,42 +44,42 @@ interface CustomerAddressBunchProcessorInterface extends CustomerAddressProcesso
     /**
      * Return's the action with the customer address CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Address\Actions\CustomerAddressActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerAddressAction();
 
     /**
      * Return's the action with the customer address varchar attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Address\Actions\CustomerAddressVarcharActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerAddressVarcharAction();
 
     /**
      * Return's the action with the customer address text attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Address\Actions\CustomerAddressTextActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerAddressTextAction();
 
     /**
      * Return's the action with the customer address int attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Address\Actions\CustomerAddressIntActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerAddressIntAction();
 
     /**
      * Return's the action with the customer address decimal attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Address\Actions\CustomerAddressDecimalActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerAddressDecimalAction();
 
     /**
      * Return's the action with the customer address datetime attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Address\Actions\CustomerAddressDatetimeActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerAddressDatetimeAction();
 

--- a/symfony/Resources/config/services.xml
+++ b/symfony/Resources/config/services.xml
@@ -104,32 +104,32 @@
             <argument type="service" id="import_customer_address.repository.sql.statement"/>
         </service>
 
-        <service id="import_customer_address.action.customer.address" class="TechDivision\Import\Customer\Address\Actions\CustomerAddressAction">
+        <service id="import_customer_address.action.customer.address" class="TechDivision\Import\Actions\GenericIdentifierAction">
             <argument type="service" id="import_customer_address.action.processor.customer.address.create"/>
             <argument type="service" id="import_customer_address.action.processor.customer.address.update"/>
             <argument type="service" id="import_customer_address.action.processor.customer.address.delete"/>
         </service>
-        <service id="import_customer_address.action.customer.address.datetime" class="TechDivision\Import\Customer\Address\Actions\CustomerAddressDatetimeAction">
+        <service id="import_customer_address.action.customer.address.datetime" class="TechDivision\Import\Actions\GenericAction">
             <argument type="service" id="import_customer_address.action.processor.customer.address.datetime.create"/>
             <argument type="service" id="import_customer_address.action.processor.customer.address.datetime.update"/>
             <argument type="service" id="import_customer_address.action.processor.customer.address.datetime.delete"/>
         </service>
-        <service id="import_customer_address.action.customer.address.decimal" class="TechDivision\Import\Customer\Address\Actions\CustomerAddressDecimalAction">
+        <service id="import_customer_address.action.customer.address.decimal" class="TechDivision\Import\Actions\GenericAction">
             <argument type="service" id="import_customer_address.action.processor.customer.address.decimal.create"/>
             <argument type="service" id="import_customer_address.action.processor.customer.address.decimal.update"/>
             <argument type="service" id="import_customer_address.action.processor.customer.address.decimal.delete"/>
         </service>
-        <service id="import_customer_address.action.customer.address.int" class="TechDivision\Import\Customer\Address\Actions\CustomerAddressIntAction">
+        <service id="import_customer_address.action.customer.address.int" class="TechDivision\Import\Actions\GenericAction">
             <argument type="service" id="import_customer_address.action.processor.customer.address.int.create"/>
             <argument type="service" id="import_customer_address.action.processor.customer.address.int.update"/>
             <argument type="service" id="import_customer_address.action.processor.customer.address.int.delete"/>
         </service>
-        <service id="import_customer_address.action.customer.address.text" class="TechDivision\Import\Customer\Address\Actions\CustomerAddressTextAction">
+        <service id="import_customer_address.action.customer.address.text" class="TechDivision\Import\Actions\GenericAction">
             <argument type="service" id="import_customer_address.action.processor.customer.address.text.create"/>
             <argument type="service" id="import_customer_address.action.processor.customer.address.text.update"/>
             <argument type="service" id="import_customer_address.action.processor.customer.address.text.delete"/>
         </service>
-        <service id="import_customer_address.action.customer.address.varchar" class="TechDivision\Import\Customer\Address\Actions\CustomerAddressVarcharAction">
+        <service id="import_customer_address.action.customer.address.varchar" class="TechDivision\Import\Actions\GenericAction">
             <argument type="service" id="import_customer_address.action.processor.customer.address.varchar.create"/>
             <argument type="service" id="import_customer_address.action.processor.customer.address.varchar.update"/>
             <argument type="service" id="import_customer_address.action.processor.customer.address.varchar.delete"/>
@@ -182,6 +182,51 @@
         </service>
         <service id="import_customer_address.observer.default.shipping.address" class="TechDivision\Import\Customer\Address\Observers\DefaultShippingAddressImportObserver">
             <argument type="service" id="import_customer.processor.customer.bunch" />
+        </service>
+
+        <!--
+         | The DI configuration for the composite observers of the customer address replace operation.
+         |-->
+        <service id="import_customer_address.observer.composite.replace" class="TechDivision\Import\Observers\GenericCompositeObserver">
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.clear.customer.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.customer.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="mport_customer_address.observer.customer.address.attribute" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.default.billing.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.default.shipping.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.clean.up"" type="service"/>
+            </call>
+        </service>
+
+        <!--
+         | The DI configuration for the composite observers of the customer address add-update operation.
+         |-->
+        <service id="import_customer_address.observer.composite.add_update" class="TechDivision\Import\Observers\GenericCompositeObserver">
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.customer.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="mport_customer_address.observer.customer.address.attribute.update" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.default.billing.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.default.shipping.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.clean.up"" type="service"/>
+            </call>
         </service>
 
         <service id="import_customer_address.subject.bunch" class="TechDivision\Import\Customer\Address\Subjects\BunchSubject" shared="false">


### PR DESCRIPTION
Switch to latest techdivision/import 7.0.* version as dependency
Make Actions and ActionInterfaces deprecated, replace DI configuration with GenericAction + GenericIdentifierAction